### PR TITLE
fix: theme instance not be accessed before initialization

### DIFF
--- a/src/Concerns/HasTheme.php
+++ b/src/Concerns/HasTheme.php
@@ -25,8 +25,11 @@ trait HasTheme
         return $this;
     }
 
+    /**
+     * getTheme
+     */
     public function getTheme(): Theme
     {
-        return $this->theme;
+        return $this->theme ?? new Theme;
     }
 }

--- a/src/Theme/Theme.php
+++ b/src/Theme/Theme.php
@@ -30,6 +30,6 @@ class Theme
      */
     public function getLayout(): Layout
     {
-        return $this->layout;
+        return $this->layout ?? Layout::Default;
     }
 }


### PR DESCRIPTION
Make a default theme if the user does not use a custom theme.







