### PR TITLE
feat: add support for domains to Clusters and Modules

### DIFF
--- a/src/Clusters/Cluster.php
+++ b/src/Clusters/Cluster.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Converge\Clusters;
 
 use Closure;
+use Converge\Concerns\HasDomain;
 use Converge\Concerns\HasLabel;
 use Converge\Concerns\HasRawPath;
 use Converge\Concerns\HasSort;
@@ -18,6 +19,7 @@ use function Converge\format_url;
 
 class Cluster
 {
+    use HasDomain;
     use HasLabel;
     use HasRawPath;
     use HasSort;

--- a/src/Concerns/HasDomain.php
+++ b/src/Concerns/HasDomain.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Converge\Concerns;
+
+use BackedEnum;
+use Closure;
+
+trait HasDomain
+{
+    protected string|BackedEnum|null|Closure $domain = null;
+
+    public function domain(string|BackedEnum|Closure|null $domain): static
+    {
+        $this->domain = $domain;
+
+        return $this;
+    }
+
+    public function getDomain(): string|BackedEnum|null
+    {
+        return $this->resolve($this->domain);
+    }
+}

--- a/src/Module.php
+++ b/src/Module.php
@@ -12,6 +12,7 @@ use Converge\Concerns\CanHandleVersions;
 use Converge\Concerns\HasBrandLogo;
 use Converge\Concerns\HasCustomFooter;
 use Converge\Concerns\HasDepth;
+use Converge\Concerns\HasDomain;
 use Converge\Concerns\HasId;
 use Converge\Concerns\HasIndexPage;
 use Converge\Concerns\HasLabel;
@@ -33,6 +34,7 @@ class Module
     use HasBrandLogo;
     use HasCustomFooter;
     use HasDepth;
+    use HasDomain;
     use HasId;
     use HasIndexPage;
     use HasLabel;


### PR DESCRIPTION
I want to use converge in a multi domain app, but only expose the module providers on specific domains. With this change, the ->domain() can be set on the module providers to make that happen.

The current behavior is not changed, this only happens if ->domain() is set